### PR TITLE
Properly close HTTP response body

### DIFF
--- a/main.go
+++ b/main.go
@@ -225,7 +225,7 @@ func main() {
 			log.WithFields(log.Fields{"state": fmt.Sprintf("GeoFence: %s, Speed: %d, State: %s, Plugged In: %t, Charge Limit: %d, Charge Level: %d, Percent: %d", geoFence, speed, state, pluggedIn, chargeLimitSoc, batteryLevel, percent), "body": body}).Info()
 			lastBody = body
 			lastState = state
-			httpClient := &http.Client{}
+			httpClient := &http.Client{ Timeout: time.Second * 5 }
 			req, err := http.NewRequest(http.MethodPut, lumen, strings.NewReader(body))
 			if debug == true && err != nil {
 				log.WithFields(log.Fields{"error": err.Error()}).Info()
@@ -237,6 +237,7 @@ func main() {
 			if debug == true && err != nil {
 				log.WithFields(log.Fields{"error": err.Error()}).Info()
 			}
+			defer resp.Body.Close()
 			lastSendTime = time.Now().Unix()
 		}
 		time.Sleep(loopSleep * time.Millisecond)


### PR DESCRIPTION
This fixes a resource leak. Otherwise connections won't be re-used, and can remain open in which case the file descriptor won't be freed. I ran into this issue after a while of driving. Since I don't know Go, the solution is probably not very idiomatic :)